### PR TITLE
fixes #31 . Excludes jquery/src from the asset compile

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -112,6 +112,7 @@ grails {
       compressHtml = true
       preserveHtmlComments = false
     }
+    excludes = ["jquery/src/*", "jquery/src/**/*"]
   }
 }
 


### PR DESCRIPTION
The issue was that intro.js and outro.js was trying to get minified, but they were not compatible. Since the application.js is pulling from jquery/dist the src folder and files inside were not getting used. In this case I just excluded the src files for jquery all together so they aren't included with the war build.

This fix does end up creating a empty src folder with empty folders inside in the built war. It does not however have any of the src javascript files which were causing the issue.

I believe it would also be possible to set minifyJs off for jquery, but this solution ensures that the jquery/dist files are getting minified.