### PR TITLE
Correct indentation on groovy conf

### DIFF
--- a/grails-app/conf/DataSource.groovy
+++ b/grails-app/conf/DataSource.groovy
@@ -66,8 +66,9 @@ environments {
                defaultTransactionIsolation = java.sql.Connection.TRANSACTION_READ_COMMITTED
             }
         }
-        docker {
-          dataSource {
+    }
+    docker {
+        dataSource {
             dbCreate = "update"
             driverClassName = "com.mysql.jdbc.Driver"
             dialect = org.hibernate.dialect.MySQL5InnoDBDialect
@@ -88,26 +89,25 @@ environments {
             password = "$pass"
 
             properties {
-              // See http://grails.org/doc/latest/guide/conf.html#dataSource for documentation
-              jmxEnabled = true
-              initialSize = 5
-              maxActive = 50
-              minIdle = 5
-              maxIdle = 25
-              maxWait = 10000
-              maxAge = 10 * 60000
-              timeBetweenEvictionRunsMillis = 5000
-              minEvictableIdleTimeMillis = 60000
-              validationQuery = "SELECT 1"
-              validationQueryTimeout = 3
-              validationInterval = 15000
-              testOnBorrow = true
-              testWhileIdle = true
-              testOnReturn = false
-              jdbcInterceptors = "ConnectionState"
-              defaultTransactionIsolation = java.sql.Connection.TRANSACTION_READ_COMMITTED
+                // See http://grails.org/doc/latest/guide/conf.html#dataSource for documentation
+                jmxEnabled = true
+                initialSize = 5
+                maxActive = 50
+                minIdle = 5
+                maxIdle = 25
+                maxWait = 10000
+                maxAge = 10 * 60000
+                timeBetweenEvictionRunsMillis = 5000
+                minEvictableIdleTimeMillis = 60000
+                validationQuery = "SELECT 1"
+                validationQueryTimeout = 3
+                validationInterval = 15000
+                testOnBorrow = true
+                testWhileIdle = true
+                testOnReturn = false
+                jdbcInterceptors = "ConnectionState"
+                defaultTransactionIsolation = java.sql.Connection.TRANSACTION_READ_COMMITTED
             }
-          }
         }
     }
 }


### PR DESCRIPTION
The docker environment was actually embedded within the production environment meaning it wasn't possible to set with `-Dgrails.env=docker`.