### PR TITLE
Video player keyboard shortcuts

### DIFF
--- a/grails-app/assets/javascripts/streama-app/templates/streama-video-player.tpl.htm
+++ b/grails-app/assets/javascripts/streama-app/templates/streama-video-player.tpl.htm
@@ -1,7 +1,19 @@
 <div class="video-wrapper-inner"  ng-mousemove="showControls()" ng-mouseleave="delayHideControls()">
 
-  <div class="volume-info" ng-show="volumeChanged">
-    {{volumeLevel * 10}}% Volume
+  <div>
+    <div class="volume-info" ng-show="volumeChanged">
+      {{volumeLevel * 10}}% Volume
+    </div>
+
+    <div class="volume-info" ng-show="currentTimeChanged">
+      <br>
+      <strong ng-show="currentTime">
+        <span ng-if="currentTime >= 3600">{{currentTime | secondsToDateTime | date:'hh:mm:ss'}}</span>
+        <span ng-if="currentTime < 3600">{{currentTime | secondsToDateTime | date:'mm:ss'}}</span>
+      </strong>
+      <span ng-if="videoDuration >= 3600">{{videoDuration | secondsToDateTime | date:'hh:mm:ss'}}</span>
+      <span ng-if="videoDuration < 3600">{{videoDuration | secondsToDateTime | date:'mm:ss'}}</span>
+    </div>
   </div>
 
   <i class="ion-android-arrow-back player-back" ng-class="{'visible': controlsVisible}" ng-click="closeVideo()"></i>
@@ -28,7 +40,7 @@
   <div class="player-controls-wrapper player-active no-select" ng-class="{'visible': controlsVisible}" ng-hide="loading && !initialPlay">
 
     <div class="slider-ui-wrapper" ng-show="!volumeOpen">
-      <div class="player-ui-slider" ui-slider="scrubberOptions" min="0" max="{{videoDuration}}" ng-model="currentTime"></div>
+      <div id="playerDurationSlider" class="player-ui-slider" ui-slider="scrubberOptions" min="0" max="{{videoDuration}}" ng-model="currentTime"></div>
       <div class="time-display">
         <strong ng-show="currentTime">
           <span ng-if="currentTime >= 3600">{{currentTime | secondsToDateTime | date:'hh:mm:ss'}}</span>
@@ -52,12 +64,12 @@
         'ion-volume-medium': volumeLevel >= 3 && volumeLevel < 6,
         'ion-volume-high': volumeLevel >= 6
         }" ng-click="playerVolumeToggle()"
-          ></i>
+        ></i>
 
         <div id="player-menu-volume" class="player-menu" ng-show="volumeOpen">
           <div class="volume-menu-content">
 
-            <div class="player-ui-slider volume-scrubber" ui-slider="volumeScrubberOptions"  min="0" max="10" step="1" ng-model="volumeLevel"></div>
+            <div id="playerVolumeSlider" class="player-ui-slider volume-scrubber" ui-slider="volumeScrubberOptions"  min="0" max="10" step="1" ng-model="volumeLevel"></div>
           </div>
         </div>
       </div>
@@ -132,3 +144,5 @@
   </video>
 
 </div>
+
+


### PR DESCRIPTION
Shortcut keys:
-Arrow keys up or down: volume.
-Arrow keys left or right: video time skip (20 seconds).
-Hold ctrl + press arrow keys to left or right: skip further (60 seconds).
-Alt + enter: toggle full screen.
-Backspace or delete: close video.
-S: toggle subtitles.
-M: toggle mute.

Miscellaneous:
-The fullscreen mode ends when you shut down the video player.
-Video's current time and duration are shown in upper right corner of the screen when the skip shortcut keys are used.
-The shortcut keys are disabled after the user closes the video player.
-Tested with Chrome and Firefox.

Issues:
-The player's current time updates slowly after skips are used.

Possible future improvements:
-The user can change skipping intervals from settings?