### PR TITLE
Added functionality to search for shows on Manage Content.  Fix bug #310

### DIFF
--- a/grails-app/assets/javascripts/streama/controllers/admin-shows-ctrl.js
+++ b/grails-app/assets/javascripts/streama/controllers/admin-shows-ctrl.js
@@ -1,24 +1,55 @@
 
+
 angular.module('streama').controller('adminShowsCtrl', ['$scope', 'apiService', '$state', 'modalService', function ($scope, apiService, $state, modalService) {
 
 	$scope.loading = true;
+  $scope.hasMovieDBKey = true;
   $scope.searchText = "Search Show from collection or TheMovieDB...";
+
+  apiService.theMovieDb.hasKey().success(function (data) {
+    if (!data.key) {
+      $scope.hasMovieDBKey = false;
+      $scope.searchText = "Search Show from collection...";
+    }
+  });
 
 	apiService.tvShow.list().success(function (data) {
 		$scope.shows = data;
 		$scope.loading = false;
 	});
 
-
-  apiService.theMovieDb.hasKey().success(function (data) {
-    if (!data.key) {
-      $scope.searchText = "Search Show from collection...";
-    }
-  });
-
-	$scope.openShowModal = function () {
+  $scope.openShowModal = function () {
 		modalService.tvShowModal(null, function (data) {
 			$state.go('admin.show', {showId: data.id});
 		});
 	};
+
+  $scope.doSearch = function (query) {
+    if ($scope.hasMovieDBKey) {
+      return apiService.theMovieDb.search('tv', query).then(function (data) {
+        $scope.suggestedShows = data.data;
+      });
+    }
+  };
+
+  $scope.addFromSuggested = function (show, redirect) {
+    var tempShow = angular.copy(show);
+    var apiId = tempShow.id;
+    delete tempShow.id;
+    tempShow.apiId = apiId;
+
+    apiService.tvShow.save(tempShow).success(function (data) {
+      if(redirect){
+        $state.go('admin.show', {showId: data.id});
+      }else{
+        $scope.shows.push(data);
+      }
+    });
+  };
+
+  $scope.alreadyAdded = function (show) {
+    console.log('%c show', 'color: deeppink; font-weight: bold; text-shadow: 0 0 5px deeppink;', show);
+    return show.id && _.find($scope.shows, {apiId: show.id.toString()});
+  };
+
 }]);

--- a/grails-app/assets/javascripts/streama/templates/admin-shows.tpl.htm
+++ b/grails-app/assets/javascripts/streama/templates/admin-shows.tpl.htm
@@ -7,7 +7,7 @@
 
 <div class="row">
   <div class="col-md-5">
-    <input placeholder="{{searchText}}" type="text" ng-model="search" class="form-control input-sm" />
+    <input placeholder="{{searchText}}" type="text" ng-model="search" ng-change="doSearch(search)" class="form-control input-sm" />
   </div>
 </div>
 
@@ -41,3 +41,22 @@
 </div>
 
 
+<div ng-if="suggestedShows.length">
+  <hr>
+  <h3>Want to add a new Show?</h3>
+  <div class="media-list similar-media">
+    <div class="media-list-item" ng-repeat="show in suggestedShows | filter:search | orderBy: '-vote_count'" ng-if="!alreadyAdded(show)">
+      <div class="hover-overlay">
+        <div>
+          <button class="btn btn-primary btn-sm btn-block" ng-click="addFromSuggested(show, true)">Add and Open</button>
+          <button class="btn btn-primary btn-sm btn-block" ng-click="addFromSuggested(show, false)">Add and Continue</button>
+        </div>
+      </div>
+      <div class="media-item" >
+        <img ng-src="https://image.tmdb.org/t/p/w300/{{show.poster_path}}"/>
+      </div>
+      <div class="media-meta">Release: {{::show.release_date.substring(0, 4)}} | <i class="ion-ios-star"></i> {{::show.vote_average}}</div>
+    </div>
+  </div>
+
+</div>


### PR DESCRIPTION
Added the functionality so that when in 'Manage Content' under 'TV Shows', the search bar populates movies from theMovieDB with the text' Want to add a new Show?', and displays related movies from database on that page.  This functions just as when searching for a movie.  I created a bug in #310 for this issue and am now trying to fix it.  

Thanks.