### PR TITLE
add missing PROFIlE.SAVE_PASS in english translation

### DIFF
--- a/grails-app/assets/javascripts/streama/translations/EN_us.js
+++ b/grails-app/assets/javascripts/streama/translations/EN_us.js
@@ -55,12 +55,12 @@ angular.module('streama.translations').config(function ($translateProvider) {
 		CHANGE_PASSWORD: 'Change Password',
 		LANGUAGE_en: 'English',
 		LANGUAGE_de: 'German',
-    	LANGUAGE_fr: 'French',
+		LANGUAGE_fr: 'French',
 		LANGUAGE_es: 'Spanish',
 		LANGUAGE_kr: 'Korean',
 		LANGUAGE_nl: 'Dutch',
 		LANGUAGE_pt: 'Portuguese',
-    LANGUAGE_da: 'Danish',
+		LANGUAGE_da: 'Danish',
 
 		PROFIlE: {
 			USERNAME: 'Username',
@@ -76,7 +76,8 @@ angular.module('streama.translations').config(function ($translateProvider) {
 			REPEAT_PASS: 'Repeat Password',
 			PASS_ERROR_EMPTY: 'The password can not be empty',
 			PASS_ERROR_LENGTH: 'The password must be at least 6 characters long',
-			PASS_ERROR_REPEAT: 'The passwords need to match'
+			PASS_ERROR_REPEAT: 'The passwords need to match',
+			SAVE_PASS: 'Set new password'
 		},
 
 		SORT_OPTIONS: {


### PR DESCRIPTION
PROFIlE.SAVE_PASS was missing in the english translation. Is there any reason for the lowercase L in profile?