### PR TITLE
move loading spinner to the screen center

### DIFF
--- a/grails-app/assets/stylesheets/_player.scss
+++ b/grails-app/assets/stylesheets/_player.scss
@@ -116,6 +116,7 @@ streama-video-player{
     top: 50%;
     left: 50%;
     width: auto;
+    margin-left: -48px;
 
     >div{
       background: $primary;

--- a/grails-app/assets/stylesheets/style.css
+++ b/grails-app/assets/stylesheets/style.css
@@ -1450,7 +1450,8 @@ streama-video-player.nocursor {
   position: absolute;
   top: 50%;
   left: 50%;
-  width: auto; }
+  width: auto;
+  margin-left: -48px; }
   .player-wrapper .spinner > div {
     background: #B0DDEF;
     width: 20px;


### PR DESCRIPTION
The loading spinner in the player is currently centered to its left border. By moving it it's width/2 (48px) left it will be centered correctly.