### PR TITLE
Mapping of user domain to 'users' table

### DIFF
--- a/grails-app/domain/streama/User.groovy
+++ b/grails-app/domain/streama/User.groovy
@@ -36,6 +36,8 @@ class User {
 	}
 
 	static mapping = {
+    //User is reserved keyword in some systems, like PostgreSQL
+    table 'users'
 		password column: '`password`'
 		cache true
 	}


### PR DESCRIPTION
Set up fails because 'user' is a reserved name in some RDBMS like Postgresql