### PR TITLE
Changed bindkey for fullscreen FROM "alt+enter" TO "f"

### DIFF
--- a/grails-app/assets/javascripts/streama/directives/streama-video-player-directive.js
+++ b/grails-app/assets/javascripts/streama/directives/streama-video-player-directive.js
@@ -414,7 +414,7 @@ angular.module('streama').directive('streamaVideoPlayer', [
 						video.currentTime -= longSkippingDuration;
 					}, 'keyup');
 
-					Mousetrap.bind('alt+enter', function (event) {
+					Mousetrap.bind('f', function (event) {
 						event.preventDefault();
 						$scope.fullScreen();
 					});


### PR DESCRIPTION
Using the "f" key is in parity with Netflix, Amazon Prime Video, and Hulu. I didn't know about "alt+enter" because I have that bound to something else in Compiz :)

This is just a minor usability request. No code changes, other than which bindkey to use. 
I also checked the other bindkeys, and "f" is not among them. There shouldn't be any collisions.