### PR TITLE
Base path removal

### DIFF
--- a/grails-app/assets/javascripts/streama/controllers/player-ctrl.js
+++ b/grails-app/assets/javascripts/streama/controllers/player-ctrl.js
@@ -8,9 +8,8 @@ angular.module('streama').controller('playerCtrl', [
 			$scope.video = data;
 
 			var missingFileError = playerService.handleMissingFileError($scope.video);
-			var wrongBasePathError = playerService.handleWrongBasepathError($scope.video);
 
-			if(!missingFileError && !wrongBasePathError){
+			if(!missingFileError){
 				$scope.videoOptions = playerService.setVideoOptions($scope.video);
 			}
 

--- a/grails-app/assets/javascripts/streama/controllers/settings-settings-ctrl.js
+++ b/grails-app/assets/javascripts/streama/controllers/settings-settings-ctrl.js
@@ -1,6 +1,10 @@
 'use strict';
 
-angular.module('streama').controller('settingsSettingsCtrl', ['$scope', 'apiService', '$sce', 'uploadService', function ($scope, apiService, $sce, uploadService) {
+angular.module('streama').controller('settingsSettingsCtrl',
+      ['$scope', 'apiService', '$sce', 'uploadService', 'fileService',
+      function ($scope, apiService, $sce, uploadService, fileService) {
+
+  $scope.fileService = fileService;
 
   apiService.settings.list().success(function (data) {
     $scope.settings = data;
@@ -60,8 +64,9 @@ angular.module('streama').controller('settingsSettingsCtrl', ['$scope', 'apiServ
 				uploadService.doUpload($scope.uploadStatus, 'file/upload.json?isPublic=true', function (data) {
 					$scope.uploadStatus.percentage = null;
 					if(data.error) return
-					
-					setting.value = data.src;
+
+					setting.value = "upload:" + data.id;
+					fileService.getAssetFromSetting(setting);
 				}, function () {}, files);
 			}else{
 				alertify.error("You have to set and save Upload Directory first");

--- a/grails-app/assets/javascripts/streama/services/api-service.js
+++ b/grails-app/assets/javascripts/streama/services/api-service.js
@@ -129,6 +129,9 @@ angular.module('streama').factory('apiService', function ($http, $rootScope, con
 			},
       save: function(data) {
         return $http.post('file/save.json', data);
+      },
+      getURL: function (id) {
+        return $http.get('file/getURL.json', {params: {id: id}});
       }
     },
 

--- a/grails-app/assets/javascripts/streama/services/file-service.js
+++ b/grails-app/assets/javascripts/streama/services/file-service.js
@@ -1,0 +1,21 @@
+'use strict';
+
+angular.module('streama').factory('fileService',[ 'apiService', '$sce' , function ( apiService, $sce) {
+  return {
+    getAssetFromSetting: function (setting) {
+
+      var assetURL = setting.value;
+
+      if(assetURL.startsWith("upload:")){
+        var id = assetURL.split(":")[1]
+        apiService.file.getURL(id)
+          .success(function (data) {  setting.src = data.url})
+
+      }else{
+        setting.src = assetURL;
+      }
+
+
+    }
+  };
+}]);

--- a/grails-app/assets/javascripts/streama/services/player-service.js
+++ b/grails-app/assets/javascripts/streama/services/player-service.js
@@ -201,26 +201,6 @@ angular.module('streama').factory('playerService',
         return hasError;
       },
 
-      handleWrongBasepathError: function (video) {
-        var hasError = false;
-        var videoSource = video.files[0].src;
-        var externalLink = video.files[0].externalLink;
-        var basePath = location.origin + contextPath;
-
-        if(videoSource && videoSource.indexOf(basePath) == -1 && !externalLink){
-          hasError = true;
-          alertify.alert($filter('translate')('MESSAGES.WRONG_BASEPATH', {basePath: basePath}), function () {
-            if(_.find($rootScope.currentUser.authorities, {authority: "ROLE_ADMIN"})){
-              $state.go('settings.settings');
-            }else{
-              $state.go('dash', {});
-            }
-
-          });
-        }
-        return hasError;
-      },
-
       registerSocketListener: function () {
         if($stateParams.sessionId){
           socketService.registerPlayerSessonListener($stateParams.sessionId);

--- a/grails-app/assets/javascripts/streama/templates/settings-settings.tpl.htm
+++ b/grails-app/assets/javascripts/streama/templates/settings-settings.tpl.htm
@@ -22,7 +22,7 @@
     <div ng-switch="setting.settingsType">
       <div ng-switch-when="string">
         <div class="col-sm-7" ng-class="{'has-error has-feedback': setting.invalid, 'has-success has-feedback': setting.valid}">
-          <input ng-required="setting.required" type="text" class="form-control" ng-model="setting.value" placeholder="{{setting.settingsKey}}" ng-change="changeValue(setting)" 
+          <input ng-required="setting.required" type="text" class="form-control" ng-model="setting.value" placeholder="{{setting.settingsKey}}" ng-change="changeValue(setting)"
         				ng-blur="(!setting.valid && setting.dirty && setting.validationRequired!==false)?validateSettings(setting):fasle">
 
           <span class="glyphicon ion-close form-control-feedback" ng-show="setting.invalid" aria-hidden="true"></span>
@@ -46,7 +46,7 @@
          </div>
          <div class="col-md-6">
           <div>
-            <img class="pull-right" ng-show="setting.value" ng-src="{{setting.value}}" alt="Streama Logo">
+            <img class="pull-right" ng-show="setting.value" ng-init="fileService.getAssetFromSetting(setting)" ng-src="{{setting.src}}" alt="Streama Logo">
           </div>
           <div>
             <input class="form-control input-sm" type="text" ng-model="setting.value" />

--- a/grails-app/controllers/streama/FileController.groovy
+++ b/grails-app/controllers/streama/FileController.groovy
@@ -21,6 +21,18 @@ class FileController {
   def theMovieDbService
   def bulkCreateService
 
+  def getURL(){
+    if (!params.id) {
+      return
+    }
+    def file = File.get(params.getInt('id'))
+
+    def responseObj = [url: file.getSrc()]
+
+    render (responseObj as JSON)
+
+  }
+
   def index(){
     def filter = params.filter
     def responseObj = [

--- a/grails-app/services/streama/UploadService.groovy
+++ b/grails-app/services/streama/UploadService.groovy
@@ -108,6 +108,14 @@ class UploadService {
   }
 
   def getFileSrc(File file){
-    return "file/serve/" + file.id + file.extension
+    def uploadPrefix = grailsApplication.config.streama.uploadPrefix
+
+    if(uploadPrefix){
+      uploadPrefix = uploadPrefix.replaceAll('/$', '')
+    }else {
+      uploadPrefix = ""
+    }
+
+    return uploadPrefix + "/file/serve/" + file.id + file.extension
   }
 }

--- a/grails-app/services/streama/UploadService.groovy
+++ b/grails-app/services/streama/UploadService.groovy
@@ -108,14 +108,14 @@ class UploadService {
   }
 
   def getFileSrc(File file){
-    def uploadPrefix = grailsApplication.config.streama.uploadPrefix
+    def servePrefix = grailsApplication.config.streama.servePrefix
 
-    if(uploadPrefix){
-      uploadPrefix = uploadPrefix.replaceAll('/$', '')
+    if(servePrefix){
+      servePrefix = servePrefix.replaceAll('/$', '')
     }else {
-      uploadPrefix = ""
+      servePrefix = ""
     }
 
-    return uploadPrefix + "/file/serve/" + file.id + file.extension
+    return servePrefix + "/file/serve/" + file.id + file.extension
   }
 }

--- a/grails-app/services/streama/UploadService.groovy
+++ b/grails-app/services/streama/UploadService.groovy
@@ -39,7 +39,7 @@ class UploadService {
     String extension = rawFile.originalFilename[index..-1];
     def originalFilenameNoExt = rawFile.originalFilename[0..(index-1)]
     def contentType = rawFile.contentType;
-	
+
 	def allowedTypes = grailsApplication.config.streama.uploadtypes
 
 	//If the file upload content type isn't in the upload types array, fail the upload.
@@ -51,7 +51,7 @@ class UploadService {
     rawFile.transferTo(targetFile)
 
     File file = createFileFromUpload(sha256Hex, rawFile, extension, originalFilenameNoExt + extension, contentType, params)
-	
+
 	  //log.debug(file)
     return file
   }
@@ -108,8 +108,6 @@ class UploadService {
   }
 
   def getFileSrc(File file){
-    def baseUrl = settingsService.baseUrl
-    baseUrl = baseUrl.replaceAll('/$', '')
-    return baseUrl  + "/file/serve/" + file.id + file.extension
+    return "file/serve/" + file.id + file.extension
   }
 }

--- a/grails-app/taglib/streama/AssetSettingTagLib.groovy
+++ b/grails-app/taglib/streama/AssetSettingTagLib.groovy
@@ -1,0 +1,27 @@
+package streama
+
+class AssetSettingTagLib {
+
+    def getAssetFromSetting(setting){
+      if(setting.startsWith("upload:")){
+        def id = setting.split(":")[1]
+        def file = File.get(id)
+
+        return file.getSrc()
+      }else{
+        return setting
+      }
+    }
+
+    def linkRelIconSetting = { attribs ->
+      def setting = attribs['setting']
+
+      out << '<link rel="icon" href="'+getAssetFromSetting(setting)+'" type="image/x-icon">'
+    }
+
+    def imgSetting = { attribs ->
+      def setting = attribs['setting']
+
+      out << '<img src="'+getAssetFromSetting(setting)+'" alt="Streama">'
+    }
+}

--- a/grails-app/views/index.gsp
+++ b/grails-app/views/index.gsp
@@ -4,7 +4,7 @@
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-    <title>${streama.Settings.findByName('title').value}</title>
+    <title>${Settings.findByName('title').value}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
 
     <style type="text/css">
@@ -15,7 +15,7 @@
 
     <asset:stylesheet src="vendor.css"/>
     <asset:stylesheet src="application.css"/>
-    <link rel="icon" href="${streama.Settings.findByName('favicon').value}" type="image/x-icon">
+    <g:linkRelIconSetting setting="${Settings.findByName('favicon').value}"></g:linkRelIconSetting>
 
     <script type="text/javascript">
         window.contextPath = "${request.contextPath}";

--- a/grails-app/views/templates/_header.gsp
+++ b/grails-app/views/templates/_header.gsp
@@ -1,7 +1,7 @@
 <header class="main" ng-if="!isCurrentState('player')">
   <div class="pull-left flex">
     <a class="logo" ui-sref="dash">
-      <img ng-show="$root.getSetting('logo')" ng-src="{{$root.getSetting('logo').value}}" src="/assets/logo.png" alt="${streama.Settings.findByName('title').value}">
+      <img ng-show="$root.getSetting('logo')" ng-init="fileService.getAssetFromSetting($root.getSetting('logo'))" ng-src="{{$root.getSetting('logo').src}}" src="/assets/logo.png" alt="${streama.Settings.findByName('title').value}">
       <div ng-show="$root.getSetting('show_version_num').value == true" class="version">v${grailsApplication.metadata.getApplicationVersion()}</div>
       <div class="spinner" ng-show="baseData.loading">
         <div class="bounce1"></div>

--- a/grails-app/views/templates/_header_anonymous.gsp
+++ b/grails-app/views/templates/_header_anonymous.gsp
@@ -1,7 +1,7 @@
 <header class="main" ng-if="!isCurrentState('player')">
   <div class="pull-left flex">
     <a class="logo" ui-sref="dash">
-      <img ng-show="$root.getSetting('logo')" ng-src="{{$root.getSetting('logo').value}}" src="/assets/logo.png" alt="${streama.Settings.findByName('title').value}">
+      <img ng-show="$root.getSetting('logo')" ng-init="fileService.getAssetFromSetting($root.getSetting('logo'))" ng-src="{{$root.getSetting('logo').src}}" src="/assets/logo.png" alt="${streama.Settings.findByName('title').value}">
       <div ng-show="$root.getSetting('show_version_num').value == true" class="version">v${grailsApplication.metadata.getApplicationVersion()}</div>
       <div class="spinner" ng-show="baseData.loading">
         <div class="bounce1"></div>

--- a/grails-app/views/templates/_header_simple.gsp
+++ b/grails-app/views/templates/_header_simple.gsp
@@ -2,8 +2,8 @@
 <header class="main" ng-if="!isCurrentState('player')">
   <div class="pull-left flex">
     <a class="logo" ui-sref="dash">
-      <img src="${streama.Settings.findByName('logo').value}" alt="Streama">
-      <g:if test="${streama.Settings.findByName('show_version_num').value == 'true'}">
+      <g:imgSetting setting="${Settings.findByName('logo').value}"></g:imgSetting>
+      <g:if test="${Settings.findByName('show_version_num').value == 'true'}">
         <div class="version">v${grailsApplication.metadata.getApplicationVersion()}</div>
       </g:if>
     </a>


### PR DESCRIPTION
This removes the requirement to have the correct base URL set for playback of videos and other files. **The base URL is still used for invite links.**

For settings that are saved as a string to reference a file, they are now saved as `upload:$fileID` this is then translated to the correct URL on request. 

This also adds a setting `streama.servePrefix` that will prefix the `file/serve` path with a custom value. This is to assist with configurations where streama is not run on the root of the domain.

Fixes #334.



  