### PR TITLE
Fix issue where asset settings weren't loading on non-settings pages

### DIFF
--- a/grails-app/assets/javascripts/streama/services/file-service.js
+++ b/grails-app/assets/javascripts/streama/services/file-service.js
@@ -3,18 +3,30 @@
 angular.module('streama').factory('fileService',[ 'apiService', '$sce' , function ( apiService, $sce) {
   return {
     getAssetFromSetting: function (setting) {
-
+      if(typeof setting === "undefined")return false;
       var assetURL = setting.value;
 
-      if(assetURL.startsWith("upload:")){
-        var id = assetURL.split(":")[1]
-        apiService.file.getURL(id)
-          .success(function (data) {  setting.src = data.url})
+      if(assetURL !== setting.prevValue) {
+        //we do this so we don't get caught in an infinite loop if the value doesn't need to be changed
+        setting.prevValue = assetURL;
+
+        if (assetURL.startsWith("upload:")) {
+
+          var id = assetURL.split(":")[1];
+          apiService.file.getURL(id)
+            .success(function (data) {
+              setting.src = data.url
+              return true;
+            })
+
+        } else {
+          setting.src = assetURL;
+          return true;
+        }
 
       }else{
-        setting.src = assetURL;
+        return true;
       }
-
 
     }
   };

--- a/grails-app/assets/javascripts/streama/streama.run.js
+++ b/grails-app/assets/javascripts/streama/streama.run.js
@@ -1,4 +1,4 @@
-angular.module('streama').run(function ($window, $rootScope, $state, localStorageService, apiService, modalService, userService) {
+angular.module('streama').run(function ($window, $rootScope, $state, localStorageService, apiService, modalService, userService, fileService) {
 	apiService.currentUser().success(function (data) {
 		userService.setCurrentUser(data);
 	});
@@ -21,6 +21,12 @@ angular.module('streama').run(function ($window, $rootScope, $state, localStorag
 	$rootScope.getSetting = function (name) {
 		return _.find($rootScope.settings, {name: name}) || _.find($rootScope.settings, {settingsKey: name});
 	};
+
+  $rootScope.getSettingAsAsset = function (name){
+	  var setting = this.getSetting(name);
+    fileService.getAssetFromSetting(setting);
+    return setting
+  };
 
 	$rootScope.selectFromSearch = function (item) {
     modalService.mediaDetailModal({mediaId: item.id, mediaType: item.mediaType});

--- a/grails-app/assets/javascripts/streama/templates/settings-settings.tpl.htm
+++ b/grails-app/assets/javascripts/streama/templates/settings-settings.tpl.htm
@@ -46,7 +46,7 @@
          </div>
          <div class="col-md-6">
           <div>
-            <img class="pull-right" ng-show="setting.value" ng-init="fileService.getAssetFromSetting(setting)" ng-src="{{setting.src}}" alt="Streama Logo">
+            <img class="pull-right" ng-show="fileService.getAssetFromSetting(setting)" ng-src="{{setting.src}}" alt="Streama Logo">
           </div>
           <div>
             <input class="form-control input-sm" type="text" ng-model="setting.value" />

--- a/grails-app/views/templates/_header.gsp
+++ b/grails-app/views/templates/_header.gsp
@@ -1,7 +1,7 @@
 <header class="main" ng-if="!isCurrentState('player')">
   <div class="pull-left flex">
     <a class="logo" ui-sref="dash">
-      <img ng-show="$root.getSetting('logo')" ng-init="fileService.getAssetFromSetting($root.getSetting('logo'))" ng-src="{{$root.getSetting('logo').src}}" src="/assets/logo.png" alt="${streama.Settings.findByName('title').value}">
+      <img ng-show="$root.getSettingAsAsset('logo')" ng-src="{{$root.getSetting('logo').src}}" src="/assets/logo.png" alt="${streama.Settings.findByName('title').value}">
       <div ng-show="$root.getSetting('show_version_num').value == true" class="version">v${grailsApplication.metadata.getApplicationVersion()}</div>
       <div class="spinner" ng-show="baseData.loading">
         <div class="bounce1"></div>

--- a/grails-app/views/templates/_header_anonymous.gsp
+++ b/grails-app/views/templates/_header_anonymous.gsp
@@ -1,7 +1,7 @@
 <header class="main" ng-if="!isCurrentState('player')">
   <div class="pull-left flex">
     <a class="logo" ui-sref="dash">
-      <img ng-show="$root.getSetting('logo')" ng-init="fileService.getAssetFromSetting($root.getSetting('logo'))" ng-src="{{$root.getSetting('logo').src}}" src="/assets/logo.png" alt="${streama.Settings.findByName('title').value}">
+      <img ng-show="$root.getSettingAsAsset('logo')" ng-src="{{$root.getSetting('logo').src}}" src="/assets/logo.png" alt="${streama.Settings.findByName('title').value}">
       <div ng-show="$root.getSetting('show_version_num').value == true" class="version">v${grailsApplication.metadata.getApplicationVersion()}</div>
       <div class="spinner" ng-show="baseData.loading">
         <div class="bounce1"></div>


### PR DESCRIPTION
#511 introduced an issue where the assets (custom logo mainly) were not loading until you visited the settings page.