### PR TITLE
Header version fix

### DIFF
--- a/grails-app/views/templates/_header.gsp
+++ b/grails-app/views/templates/_header.gsp
@@ -2,14 +2,15 @@
   <div class="pull-left flex">
     <a class="logo" ui-sref="dash">
       <img ng-show="$root.getSettingAsAsset('logo')" ng-src="{{$root.getSetting('logo').src}}" src="/assets/logo.png" alt="${streama.Settings.findByName('title').value}">
-      <div ng-show="$root.getSetting('show_version_num').value == true" class="version">v${grailsApplication.metadata.getApplicationVersion()}</div>
       <div class="spinner" ng-show="baseData.loading">
         <div class="bounce1"></div>
         <div class="bounce2"></div>
         <div class="bounce3"></div>
       </div>
     </a>
-
+    <g:if test="${streama.Settings.findByName('show_version_num').value == 'true'}">
+      <div class="version">v${grailsApplication.metadata.getApplicationVersion()}</div>
+    </g:if>
     <div class="browse-genres" ng-if="isCurrentState('dash') && genres.length">
       <button class="btn btn-link toggle-menu" ng-click="toggleGenreMenu()">
         <span ng-if="selectedGenre" ng-bind="selectedGenre.name"></span>

--- a/grails-app/views/templates/_header_anonymous.gsp
+++ b/grails-app/views/templates/_header_anonymous.gsp
@@ -2,14 +2,15 @@
   <div class="pull-left flex">
     <a class="logo" ui-sref="dash">
       <img ng-show="$root.getSettingAsAsset('logo')" ng-src="{{$root.getSetting('logo').src}}" src="/assets/logo.png" alt="${streama.Settings.findByName('title').value}">
-      <div ng-show="$root.getSetting('show_version_num').value == true" class="version">v${grailsApplication.metadata.getApplicationVersion()}</div>
       <div class="spinner" ng-show="baseData.loading">
         <div class="bounce1"></div>
         <div class="bounce2"></div>
         <div class="bounce3"></div>
       </div>
     </a>
-
+    <g:if test="${streama.Settings.findByName('show_version_num').value == 'true'}">
+      <div class="version">v${grailsApplication.metadata.getApplicationVersion()}</div>
+    </g:if>
     <div class="browse-genres" ng-if="isCurrentState('dash') && genres.length">
       <button class="btn btn-link toggle-menu" ng-click="toggleGenreMenu()">
         <span ng-if="selectedGenre" ng-bind="selectedGenre.name"></span>

--- a/grails-app/views/templates/_header_simple.gsp
+++ b/grails-app/views/templates/_header_simple.gsp
@@ -3,9 +3,6 @@
   <div class="pull-left flex">
     <a class="logo" ui-sref="dash">
       <g:imgSetting setting="${Settings.findByName('logo').value}"></g:imgSetting>
-      <g:if test="${Settings.findByName('show_version_num').value == 'true'}">
-        <div class="version">v${grailsApplication.metadata.getApplicationVersion()}</div>
-      </g:if>
     </a>
   </div>
 


### PR DESCRIPTION
+ Fixes issue where sometimes the version number in the header would not show.
+ Moves version number to the right of the logo, moving to right prevents the header from changing height and looking bad.
+ Removes the version number from header_simple, just to keep the header for invite emails, etc. more *simple*.