### PR TITLE
Docker now get mysql conn string from system env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,12 @@ language: groovy
 
 services: docker
 
-script: ./gradlew check
+script: ./gradlew build
 
 after_success:
   if [ ! -z "$TRAVIS_TAG" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     docker login -u="$DOCKER_USER" -p="$DOCKER_PASS";
-    docker build -t gkiko/streama:latest .;
+    docker build -t gkiko/streama:latest -f docker/Dockerfile .;
     docker tag gkiko/streama:latest gkiko/streama:$TRAVIS_TAG;
     docker push gkiko/streama:latest;
     docker push gkiko/streama:$TRAVIS_TAG;

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-FROM java:8-jre
-
-ADD build/libs/*.war /app/streama.war
-
-WORKDIR /app
-
-EXPOSE 8080
-ENTRYPOINT ["java"]
-CMD ["-Dgrails.env=test", "-jar", "streama.war"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,10 @@
+FROM openjdk:8-jre-slim
+VOLUME /data
+EXPOSE 8080
+ENV ACTIVE_PROFILE=production
+
+WORKDIR /app
+COPY docker/entrypoint.sh entrypoint.sh
+COPY build/libs/*.war streama.war
+
+ENTRYPOINT ["sh", "entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+java -Dgrails.env=$ACTIVE_PROFILE -jar streama.war

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -20,6 +20,13 @@ environments:
             url: jdbc:mysql://localhost/streama
             username: root
             password:
+    mysql:
+        dataSource:
+            dbCreate: update
+            driverClassName:  'com.mysql.jdbc.Driver'
+            url: jdbc:mysql://${mysql_host:localhost}:${mysql_port:3306}/${mysql_db:streama}
+            username: ${mysql_user:streama}
+            password: ${mysql_password:streama}
     test:
         dataSource:
             dbCreate: update
@@ -27,7 +34,7 @@ environments:
     production:
         dataSource:
             dbCreate: update
-            url: jdbc:h2:./streama;MVCC=TRUE;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
+            url: jdbc:h2:/data/streamadb;MVCC=TRUE;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
             username: root
             password:
             properties:


### PR DESCRIPTION
I've changed the followings:
Travis CI:
- now it builds war as well (check don't do it for me)
- dockerfile moved to docker dir
Dockerfile:
- Deprecated java changed to openjdk
- It has a persistent volume now
- It allows change spring's active profile from system env
application.yml:
- Added mysql profile, values comes from system env (everything has default value)
- Production H2 file moved to another path (docker persist it). You should consider other options, like create docker profile.