### PR TITLE
implement bulk api caching

### DIFF
--- a/grails-app/assets/javascripts/streama/controllers/createFromFileCtrl.modal.js
+++ b/grails-app/assets/javascripts/streama/controllers/createFromFileCtrl.modal.js
@@ -99,6 +99,7 @@ function modalCreateFromFileCtrl($scope, $uibModalInstance, apiService, uploadSe
 
 	function runMatcher() {
 		vm.isMatcherLoading = true;
+    vm.matchResult = null;
 		var fileSelection = _.filter(vm.selection, {directory: false});
 		apiService.file.matchMetaDataFromFiles(fileSelection).success(function (data) {
 			vm.isMatcherLoading = false;

--- a/grails-app/assets/javascripts/streama/controllers/createFromFileCtrl.modal.js
+++ b/grails-app/assets/javascripts/streama/controllers/createFromFileCtrl.modal.js
@@ -139,7 +139,11 @@ function modalCreateFromFileCtrl($scope, $uibModalInstance, apiService, uploadSe
 		}
 
     apiService.file.bulkAddMediaFromFile(allFoundMatches).success(function (result) {
-      alertify.success("All matches have been added to the database and files connected");
+      if(_.some(result, {status: 4})){
+        alertify.log("not all files were added unfortunately. This is due to TheMovieDB API LIMIT constraints. We are sorry and we hope to have a fix soon. ")
+      }else{
+        alertify.success("All matches have been added to the database and files connected");
+      }
       mergeMatchResults(result);
     });
 
@@ -148,7 +152,11 @@ function modalCreateFromFileCtrl($scope, $uibModalInstance, apiService, uploadSe
 	function addSelectedFile(file) {
     var fileMatch = _.find(vm.matchResult, {"file": file.path});
     apiService.file.bulkAddMediaFromFile([fileMatch]).success(function (result) {
-      alertify.success(fileMatch.title || fileMatch.episodeName + " has been added");
+      if(_.some(result, {status: 4})){
+        alertify.log("not all files were added unfortunately. This is due to TheMovieDB API LIMIT constraints. We are sorry and we hope to have a fix soon. ")
+      }else{
+        alertify.success(fileMatch.title || fileMatch.episodeName + " has been added");
+      }
       mergeMatchResults(result);
     });
 	}

--- a/grails-app/assets/javascripts/streama/templates/modal--create-from-file-recursive-item.tpl.htm
+++ b/grails-app/assets/javascripts/streama/templates/modal--create-from-file-recursive-item.tpl.htm
@@ -31,7 +31,7 @@
     <i class="ion-document"></i> {{ file.name }}
   </div>
   <div class="col-md-3">
-    <i class="ion-load-c spin column-loading" ng-show="vm.isMatcherLoading && (!vm.getMatchForPath(file.path) || vm.getMatchForPath(file.path).status == 1)"></i>
+    <i class="ion-load-c spin column-loading" ng-show="vm.isMatcherLoading && vm.isSelected(file) && (!vm.getMatchForPath(file.path) || vm.getMatchForPath(file.path).status == 1)"></i>
      <span ng-if="vm.getMatchForPath(file.path) && vm.getMatchForPath(file.path).status == 1">
       <a ng-click="vm.openMediaDetail(vm.getMatchForPath(file.path))"><i class="ion-ios-eye"></i> Preview Match</a>
     </span>

--- a/grails-app/assets/javascripts/streama/templates/modal--create-from-file-recursive-item.tpl.htm
+++ b/grails-app/assets/javascripts/streama/templates/modal--create-from-file-recursive-item.tpl.htm
@@ -31,6 +31,7 @@
     <i class="ion-document"></i> {{ file.name }}
   </div>
   <div class="col-md-3">
+    <i class="ion-load-c spin column-loading" ng-show="vm.isMatcherLoading && (!vm.getMatchForPath(file.path) || vm.getMatchForPath(file.path).status == 1)"></i>
      <span ng-if="vm.getMatchForPath(file.path) && vm.getMatchForPath(file.path).status == 1">
       <a ng-click="vm.openMediaDetail(vm.getMatchForPath(file.path))"><i class="ion-ios-eye"></i> Preview Match</a>
     </span>

--- a/grails-app/assets/stylesheets/_admin.scss
+++ b/grails-app/assets/stylesheets/_admin.scss
@@ -113,6 +113,12 @@
     padding: 7px 0;
     border-top: 1px solid #555a5c;
   }
+
+  .column-loading{
+    width: 1em;
+    height: 1em;
+    display: inline-block;
+  }
 }
 
 .upload-poster{

--- a/grails-app/services/streama/TheMovieDbService.groovy
+++ b/grails-app/services/streama/TheMovieDbService.groovy
@@ -158,7 +158,12 @@ class TheMovieDbService {
 
   def createEntityFromApiId(type, id, data = [:]){
     def apiData = getEntryById(type, id, data)
-    def entity = createEntityFromApiData(type, apiData)
+    def entity
+    try{
+      entity = createEntityFromApiData(type, apiData)
+    }catch (e){
+      log.error("Error occured while trying to retrieve data from TheMovieDB. Please check your API-Key.")
+    }
     return entity
   }
 

--- a/grails-app/services/streama/TheMovieDbService.groovy
+++ b/grails-app/services/streama/TheMovieDbService.groovy
@@ -8,6 +8,8 @@ class TheMovieDbService {
 
   def BASE_URL = "https://api.themoviedb.org/3"
 
+  def apiCacheData = [:]
+
   def getAPI_PARAMS(){
     return "api_key=$API_KEY&language=$API_LANGUAGE"
   }
@@ -124,10 +126,18 @@ class TheMovieDbService {
   }
 
   def searchForEntry(type, name) {
+
+    def cachedApiData = apiCacheData."$type:$name"
+    if(cachedApiData){
+      return cachedApiData
+    }
     def query = URLEncoder.encode(name, "UTF-8")
 
     def JsonContent = new URL(BASE_URL + '/search/' + type + '?query=' + query + '&api_key=' + API_KEY).getText("UTF-8")
-    return new JsonSlurper().parseText(JsonContent)
+    def data = new JsonSlurper().parseText(JsonContent)
+    apiCacheData["$type:$name"] = data
+
+    return data
   }
 
   def getEntryById(String type, id, data = [:]){


### PR DESCRIPTION
This PR is a potential fix for #480 #498 and #597. 
Now the application will cache some API calls that happen over and over (like the tv-show for a bunch of episodes) as well as first looking for existing DB records, which will hopefully resolve the most common LIMIT issue. 