### PR TITLE
fix: 2 improvements across 2 files

### DIFF
--- a/grails-app/assets/javascripts/streama/controllers/admin-videos-ctrl.js
+++ b/grails-app/assets/javascripts/streama/controllers/admin-videos-ctrl.js
@@ -32,7 +32,6 @@ angular.module('streama').controller('adminVideosCtrl', ['$scope', 'apiService',
 	};
 
 	$scope.alreadyAdded = function (movie) {
-		console.log('%c movie', 'color: deeppink; font-weight: bold; text-shadow: 0 0 5px deeppink;', movie);
 		return movie.id && _.find($scope.movies, {apiId: movie.id.toString()});
 	};
 

--- a/grails-app/assets/javascripts/streama/services/upload-service.js
+++ b/grails-app/assets/javascripts/streama/services/upload-service.js
@@ -20,7 +20,6 @@ angular.module('streama').factory('uploadService', function ($http, Upload, cont
 
 						.success(callback || angular.noop)
 						.error(function (err) {
-              console.log('%c err', 'color: deeppink; font-weight: bold; text-shadow: 0 0 5px deeppink;', arguments);
               alertify.error("File upload failed. Please close this popup and try again.", 0);
               uploadStatus.percentage = null;
               (errCallback || angular.noop)(err);


### PR DESCRIPTION
## Summary

fix: 2 improvements across 2 files

## Problem

**Severity**: `Medium` | **File**: `grails-app/assets/javascripts/streama/controllers/admin-videos-ctrl.js:L29`

Multiple console.log statements are present in production code across several files. These should be removed or replaced with proper logging infrastructure.

## Solution

Remove all console.log debugging statements or use a proper logging service with appropriate log levels.

## Changes

- `grails-app/assets/javascripts/streama/controllers/admin-videos-ctrl.js` (modified)
- `grails-app/assets/javascripts/streama/services/upload-service.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v6.0.0*